### PR TITLE
Fix nested list rendering

### DIFF
--- a/notionit/types.py
+++ b/notionit/types.py
@@ -222,8 +222,9 @@ class NotionCodeBlock(TypedDict):
     code: NotionCodeContent
 
 
-class NotionBulletedListItemContent(TypedDict):
+class NotionBulletedListItemContent(TypedDict, total=False):
     rich_text: List[NotionRichText]
+    children: List["NotionExtendedBlock"]
 
 
 class NotionBulletedListItemBlock(TypedDict):
@@ -232,8 +233,9 @@ class NotionBulletedListItemBlock(TypedDict):
     bulleted_list_item: NotionBulletedListItemContent
 
 
-class NotionNumberedListItemContent(TypedDict):
+class NotionNumberedListItemContent(TypedDict, total=False):
     rich_text: List[NotionRichText]
+    children: List["NotionExtendedBlock"]
 
 
 class NotionNumberedListItemBlock(TypedDict):


### PR DESCRIPTION
## Summary
- support nested list items when converting Markdown to Notion blocks
- allow children in list item typed definitions

## Testing
- `ruff check notionit`
- `pyright`

------
https://chatgpt.com/codex/tasks/task_e_6847a4cfa5f0832588a2da4932bac52e