### PR TITLE
Handle invalid URLs in links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 * ✅ **Full Markdown Support** via [Mistune](https://mistune.readthedocs.io/)
 * 📤 **Upload to Notion** using official API
 * 📎 **File & Image Attachment Support**
+* 🔗 **Skips invalid links like anchors**
 * 📐 **LaTeX Math Block Rendering**
 * 🧩 **Plugin-based Parsing** (supports strikethrough, footnotes, task lists, etc.)
 * 📄 **Table-to-Block Conversion**

--- a/notionit/renderer.py
+++ b/notionit/renderer.py
@@ -624,10 +624,11 @@ class MistuneNotionRenderer:
             self._render_file_block(url, self._get_link_text(children_text))
             return []  # Do not return inline text
 
-        # Otherwise apply the link to all child text
-        for text_item in children_text:
-            if text_item["type"] == "text":
-                text_item["text"]["link"] = {"url": url}
+        # Only apply link if the URL is valid (skip anchors and invalid URLs)
+        if self._is_valid_url(url):
+            for text_item in children_text:
+                if text_item["type"] == "text":
+                    text_item["text"]["link"] = {"url": url}
 
         return children_text
 


### PR DESCRIPTION
## Summary
- skip invalid URL links in renderer
- document skipping of anchor links in README

## Testing
- `ruff check .`
- `pyright`

------
https://chatgpt.com/codex/tasks/task_e_6847a970f768832583dc67c6922b0f7f