### PR TITLE
Fix math block parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Default enabled plugins:
 * `def_list`
 * `abbr`
 * `ruby`
-* `math`
+* `math` (via `notionit.math_plugin.notion_math` for single-line $$ and list support)
 
 Customize them via `--plugins` or programmatically.
 

--- a/notionit/config.py
+++ b/notionit/config.py
@@ -18,6 +18,9 @@ def get_config(key: Literal["notion_base_url", "notion_api_version", "notion_tok
         else:
             raise ValueError("NOTION_TOKEN is not set")
     elif key == "notion_parser_plugins":
-        return environ.get("NOTION_PARSER_PLUGINS", "strikethrough,mark,insert,subscript,superscript,footnotes,table,task_lists,def_list,abbr,ruby,math")
+        return environ.get(
+            "NOTION_PARSER_PLUGINS",
+            "strikethrough,mark,insert,subscript,superscript,footnotes,table,task_lists,def_list,abbr,ruby,notionit.math_plugin.notion_math",
+        )
     else:
         raise ValueError(f"Invalid key: {key}")

--- a/notionit/math_plugin.py
+++ b/notionit/math_plugin.py
@@ -1,0 +1,36 @@
+from typing import TYPE_CHECKING, Match
+from mistune.plugins.math import (
+    math as base_math,
+    math_in_list as base_math_in_list,
+    math_in_quote as base_math_in_quote,
+    render_block_math,
+    render_inline_math,
+)
+
+if TYPE_CHECKING:
+    from mistune.block_parser import BlockParser
+    from mistune.core import BlockState
+    from mistune.markdown import Markdown
+
+__all__ = ["notion_math"]
+
+SINGLE_LINE_BLOCK_MATH_PATTERN = r"^ {0,3}\$\$(?P<math_text_single>[^\n]+?)\$\$[ \t]*$"
+
+def parse_single_line_math(block: "BlockParser", m: Match[str], state: "BlockState") -> int:
+    text = m.group("math_text_single")
+    state.append_token({"type": "block_math", "raw": text})
+    return m.end() + 1
+
+
+def notion_math(md: "Markdown") -> None:
+    """Enhanced math plugin supporting single-line block math and math in lists."""
+    base_math(md)
+    md.block.register(
+        "block_math_single", SINGLE_LINE_BLOCK_MATH_PATTERN, parse_single_line_math, before="block_math"
+    )
+    base_math_in_list(md)
+    md.block.insert_rule(md.block.list_rules, "block_math_single", before="block_math")
+    base_math_in_quote(md)
+    if md.renderer and md.renderer.NAME == "html":
+        md.renderer.register("block_math", render_block_math)
+        md.renderer.register("inline_math", render_inline_math)

--- a/notionit/renderer.py
+++ b/notionit/renderer.py
@@ -285,11 +285,24 @@ class MistuneNotionRenderer:
                 rich_text.extend(self._render_inline_children(child.get("children", [])))
             elif child.get("type") == "paragraph":
                 rich_text.extend(self._render_inline_children(child.get("children", [])))
+            elif child.get("type") == "block_math":
+                child_blocks.append({
+                    "object": "block",
+                    "type": "equation",
+                    "equation": {"expression": child.get("raw", "")},
+                })
             elif child.get("type") == "list":
                 child_blocks.extend(self._collect_list_blocks(child))
 
         if not rich_text:
-            return None
+            # Notion requires at least one text item; use empty string
+            rich_text.append(
+                {
+                    "type": "text",
+                    "text": {"content": "", "link": None},
+                    "annotations": {"bold": False, "italic": False, "strikethrough": False, "underline": False, "code": False, "color": "default"},
+                }
+            )
 
         if is_ordered:
             ordered_block: NotionNumberedListItemBlock = {


### PR DESCRIPTION
## Summary
- support single-line `$$` math and math inside lists via new plugin
- use the enhanced plugin by default
- handle equation blocks inside list items
- document math plugin in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `ruff check .`
- `pyright`

------
https://chatgpt.com/codex/tasks/task_e_6847ad031ed883258ea3260266f14ee4