### PR TITLE
Handle math blocks inside tables

### DIFF
--- a/asset/TEST_math.md
+++ b/asset/TEST_math.md
@@ -12,3 +12,7 @@ $$
 What about this?
 - $Inline math block!$
 - $$Another math block!$$
+
+| Column  | _Italic column_         |
+|-------- | ----------------------- |
+| $\alpha$| **bold $\alpha$**       |


### PR DESCRIPTION
## Summary
- render math expressions inside table cells as equation rich text

## Testing
- `pyright`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_684bd4776550832588843734c96aad4f